### PR TITLE
Further fix: dependency constraints for intuit gem

### DIFF
--- a/omniauth-intuit.gemspec
+++ b/omniauth-intuit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth', '~> 2.0.0'
+  s.add_runtime_dependency 'omniauth-oauth', '~> 1.2.0'
 
   s.add_development_dependency 'rspec', '~> 2.11'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
The wrong version was used in a previous version for the `omniauth-oauth` gem. This PR fixes it.